### PR TITLE
Add ruff linting via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Installera beroenden via pip och kör skriptet med Python 3. Exempel:
 pip install -r requirements.txt
 python main.py
 ```
+
+### Kodstandard och automatiska hooks
+
+För utveckling rekommenderas att installera dev-beroenden och aktivera
+`pre-commit` så att koden automatiskt lintas med **ruff** innan varje commit.
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Efter installationen körs lintern automatiskt. Du kan även starta den manuellt:
+
+```bash
+pre-commit run --all-files
+./scripts/run_ruff.sh
+```

--- a/main.py
+++ b/main.py
@@ -1,14 +1,14 @@
-# Inmatade värden
-vagg_bredd = 6.0          # meter
-vagg_hojd = 2.5           # meter
-brada_bredd = 0.16        # meter
-spalt_bredd = 0.005       # meter (5 mm spalt)
-tillgangliga_langder = [3.0, 3.6, 4.2, 4.8, 5.1, 5.4, 6.0]  # meter
-spill_marginal_procent = 10  # procent
-
-# Importera tabulate
+# Importer
 from math import ceil
 from tabulate import tabulate
+
+# Inmatade värden
+vagg_bredd = 6.0  # meter
+vagg_hojd = 2.5  # meter
+brada_bredd = 0.16  # meter
+spalt_bredd = 0.005  # meter (5 mm spalt)
+tillgangliga_langder = [3.0, 3.6, 4.2, 4.8, 5.1, 5.4, 6.0]  # meter
+spill_marginal_procent = 10  # procent
 
 # Effektiv bredd per bräda inklusive spalt
 effektiv_bredd = brada_bredd + spalt_bredd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pre-commit
+ruff

--- a/scripts/run_ruff.sh
+++ b/scripts/run_ruff.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# simple helper to run ruff against all files
+ruff check .


### PR DESCRIPTION
## Summary
- integrate ruff using pre-commit
- adjust imports in `main.py` so ruff passes
- document how to use ruff in README
- add dev requirements and helper script

## Testing
- `pre-commit run --files main.py README.md scripts/run_ruff.sh .pre-commit-config.yaml requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840c924cb5c8322976a16e010273e3f